### PR TITLE
Fixed RBruteForceComp.isIpBanned

### DIFF
--- a/src/Controller/Component/RBruteForceComponent.php
+++ b/src/Controller/Component/RBruteForceComponent.php
@@ -117,7 +117,7 @@ class RBruteForceComponent extends Component
     public function isIpBanned($options = [])
     {
         $this->options = array_merge($this->options, $options);
-        return (bool)$this->getCount() >= $this->options['maxAttempts'];
+        return (int)$this->getCount() >= (int)$this->options['maxAttempts'];
     }
 
     /**


### PR DESCRIPTION
Typecasting $this->getCount() as bool is causing isIpBanned to return false when there are no current counts, but true then there is one count.  To fix this, the actual integers should be compared.